### PR TITLE
fix build with pkg/term 1.1.0

### DIFF
--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -3,9 +3,8 @@
 package term
 
 import (
-	"syscall"
-
 	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 // SetRaw put terminal into a raw mode
@@ -15,12 +14,12 @@ func SetRaw(fd int) error {
 		return err
 	}
 
-	n.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK |
-		syscall.ISTRIP | syscall.INLCR | syscall.IGNCR |
-		syscall.ICRNL | syscall.IXON
-	n.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.IEXTEN | syscall.ISIG | syscall.ECHONL
-	n.Cflag &^= syscall.CSIZE | syscall.PARENB
-	n.Cc[syscall.VMIN] = 1
-	n.Cc[syscall.VTIME] = 0
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*syscall.Termios)(&n))
+	n.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK |
+		unix.ISTRIP | unix.INLCR | unix.IGNCR |
+		unix.ICRNL | unix.IXON
+	n.Lflag &^= unix.ECHO | unix.ICANON | unix.IEXTEN | unix.ISIG | unix.ECHONL
+	n.Cflag &^= unix.CSIZE | unix.PARENB
+	n.Cc[unix.VMIN] = 1
+	n.Cc[unix.VTIME] = 0
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -4,18 +4,18 @@ package term
 
 import (
 	"sync"
-	"syscall"
 
 	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 var (
-	saveTermios     syscall.Termios
+	saveTermios     unix.Termios
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (syscall.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd


### PR DESCRIPTION
New version of pkg/term changed the expected type of termios.Tcsetattr() and termios.Tcgetattr() from syscall.Termios to unix.Termios, this simple patch reflects this update and fixes build.